### PR TITLE
1. Update according to review comments

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -62,6 +62,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.21/stable
+          bootstrap-options: --agent-version="2.9.22"
           charmcraft-channel: latest/candidate
       - run: |
           sg microk8s -c "tox -e ${{ matrix.charm }}-integration"

--- a/charms/kfp-profile-controller/files/upstream/sync.py
+++ b/charms/kfp-profile-controller/files/upstream/sync.py
@@ -39,13 +39,22 @@ def emit_settings_to_logs(settings):
     logger.info(f"Settings = {safe_settings}")
 
 
-def get_settings_from_env(controller_port=None,
-                          visualization_server_image=None, frontend_image=None,
-                          visualization_server_tag=None, frontend_tag=None,
-                          disable_istio_sidecar=None, minio_access_key=None, minio_secret_key=None,
-                          minio_host=None, minio_port=None, minio_namespace=None,
-                          kfp_default_pipeline_root=None, metadata_grpc_service_host=None,
-                          metadata_grpc_service_port=None):
+def get_settings_from_env(
+    controller_port=None,
+    visualization_server_image=None,
+    frontend_image=None,
+    visualization_server_tag=None,
+    frontend_tag=None,
+    disable_istio_sidecar=None,
+    minio_access_key=None,
+    minio_secret_key=None,
+    minio_host=None,
+    minio_port=None,
+    minio_namespace=None,
+    kfp_default_pipeline_root=None,
+    metadata_grpc_service_host=None,
+    metadata_grpc_service_port=None,
+):
     """
     Returns a dict of settings from environment variables relevant to the controller
 
@@ -68,80 +77,86 @@ def get_settings_from_env(controller_port=None,
         metadata_grpc_service_port: 8080
     """
     settings = dict()
-    settings["controller_port"] = \
-        controller_port or \
-        os.environ.get("CONTROLLER_PORT", "8080")
+    settings["controller_port"] = controller_port or os.environ.get("CONTROLLER_PORT", "8080")
 
-    settings["visualization_server_image"] = \
-        visualization_server_image or \
-        os.environ.get("VISUALIZATION_SERVER_IMAGE", "gcr.io/ml-pipeline/visualization-server")
+    settings["visualization_server_image"] = visualization_server_image or os.environ.get(
+        "VISUALIZATION_SERVER_IMAGE", "gcr.io/ml-pipeline/visualization-server"
+    )
 
-    settings["frontend_image"] = \
-        frontend_image or \
-        os.environ.get("FRONTEND_IMAGE", "gcr.io/ml-pipeline/frontend")
+    settings["frontend_image"] = frontend_image or os.environ.get(
+        "FRONTEND_IMAGE", "gcr.io/ml-pipeline/frontend"
+    )
 
     # Look for specific tags for each image first, falling back to
     # previously used KFP_VERSION environment variable for backwards
     # compatibility
-    settings["visualization_server_tag"] = \
-        visualization_server_tag or \
-        os.environ.get("VISUALIZATION_SERVER_TAG") or \
-        os.environ["KFP_VERSION"]
+    settings["visualization_server_tag"] = (
+        visualization_server_tag
+        or os.environ.get("VISUALIZATION_SERVER_TAG")
+        or os.environ["KFP_VERSION"]
+    )
 
-    settings["frontend_tag"] = \
-        frontend_tag or \
-        os.environ.get("FRONTEND_TAG") or \
-        os.environ["KFP_VERSION"]
+    settings["frontend_tag"] = (
+        frontend_tag or os.environ.get("FRONTEND_TAG") or os.environ["KFP_VERSION"]
+    )
 
-    settings["disable_istio_sidecar"] = \
-        disable_istio_sidecar if disable_istio_sidecar is not None \
-            else os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
+    settings["disable_istio_sidecar"] = (
+        disable_istio_sidecar
+        if disable_istio_sidecar is not None
+        else os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
+    )
 
-    settings["minio_access_key"] = \
-        minio_access_key or \
-        base64.b64encode(bytes(os.environ.get("MINIO_ACCESS_KEY"), 'utf-8')).decode('utf-8')
+    settings["minio_access_key"] = minio_access_key or base64.b64encode(
+        bytes(os.environ.get("MINIO_ACCESS_KEY"), "utf-8")
+    ).decode("utf-8")
 
-    settings["minio_secret_key"] = \
-        minio_secret_key or \
-        base64.b64encode(bytes(os.environ.get("MINIO_SECRET_KEY"), 'utf-8')).decode('utf-8')
+    settings["minio_secret_key"] = minio_secret_key or base64.b64encode(
+        bytes(os.environ.get("MINIO_SECRET_KEY"), "utf-8")
+    ).decode("utf-8")
 
-    settings["minio_host"] = \
-        minio_host or \
-        os.environ.get("MINIO_HOST", "minio")
+    settings["minio_host"] = minio_host or os.environ.get("MINIO_HOST", "minio")
 
-    settings["minio_port"] = \
-        minio_port or \
-        os.environ.get("MINIO_PORT", "9000")
+    settings["minio_port"] = minio_port or os.environ.get("MINIO_PORT", "9000")
 
-    settings["minio_namespace"] = \
-        minio_namespace or \
-        os.environ.get("MINIO_NAMESPACE", "kubeflow")
+    settings["minio_namespace"] = minio_namespace or os.environ.get("MINIO_NAMESPACE", "kubeflow")
 
     # KFP_DEFAULT_PIPELINE_ROOT is optional
-    settings["kfp_default_pipeline_root"] = \
-        kfp_default_pipeline_root or \
-        os.environ.get("KFP_DEFAULT_PIPELINE_ROOT")
+    settings["kfp_default_pipeline_root"] = kfp_default_pipeline_root or os.environ.get(
+        "KFP_DEFAULT_PIPELINE_ROOT"
+    )
 
-    settings["metadata_grpc_service_host"] = \
-        metadata_grpc_service_host or \
-        os.environ.get("METADATA_GRPC_SERVICE_HOST", "metadata-grpc-service.kubeflow")
+    settings["metadata_grpc_service_host"] = metadata_grpc_service_host or os.environ.get(
+        "METADATA_GRPC_SERVICE_HOST", "metadata-grpc-service.kubeflow"
+    )
 
-    settings["metadata_grpc_service_port"] = \
-        metadata_grpc_service_port or \
-        os.environ.get("METADATA_GRPC_SERVICE_PORT", "8080")
+    settings["metadata_grpc_service_port"] = metadata_grpc_service_port or os.environ.get(
+        "METADATA_GRPC_SERVICE_PORT", "8080"
+    )
 
     return settings
 
 
-def server_factory(visualization_server_image,
-                   visualization_server_tag, frontend_image, frontend_tag,
-                   disable_istio_sidecar, minio_access_key,
-                   minio_secret_key, minio_host, minio_namespace, minio_port,
-                   metadata_grpc_service_host, metadata_grpc_service_port,
-                   kfp_default_pipeline_root=None, url="", controller_port=8080):
+def server_factory(
+    visualization_server_image,
+    visualization_server_tag,
+    frontend_image,
+    frontend_tag,
+    disable_istio_sidecar,
+    minio_access_key,
+    minio_secret_key,
+    minio_host,
+    minio_namespace,
+    minio_port,
+    metadata_grpc_service_host,
+    metadata_grpc_service_port,
+    kfp_default_pipeline_root=None,
+    url="",
+    controller_port=8080,
+):
     """
     Returns an HTTPServer populated with Handler with customized settings
     """
+
     class Controller(BaseHTTPRequestHandler):
         def sync(self, parent, children):
             logger.info("Got new request")
@@ -149,41 +164,46 @@ def server_factory(visualization_server_image,
             # parent is a namespace
             namespace = parent.get("metadata", {}).get("name")
 
-            pipeline_enabled = parent.get("metadata", {}).get(
-                "labels", {}).get("pipelines.kubeflow.org/enabled")
+            pipeline_enabled = (
+                parent.get("metadata", {}).get("labels", {}).get("pipelines.kubeflow.org/enabled")
+            )
 
             if pipeline_enabled != "true":
-                logger.info(f"Namespace not in scope, no action taken (metadata.labels.pipelines.kubeflow.org/enabled = {pipeline_enabled}, must be 'true')")
+                logger.info(
+                    f"Namespace not in scope, no action taken (metadata.labels.pipelines.kubeflow.org/enabled = {pipeline_enabled}, must be 'true')"
+                )
                 return {"status": {}, "children": []}
 
             desired_configmap_count = 1
             desired_resources = []
             if kfp_default_pipeline_root:
                 desired_configmap_count = 2
-                desired_resources += [{
-                    "apiVersion": "v1",
-                    "kind": "ConfigMap",
-                    "metadata": {
-                        "name": "kfp-launcher",
-                        "namespace": namespace,
-                    },
-                    "data": {
-                        "defaultPipelineRoot": kfp_default_pipeline_root,
-                    },
-                }]
-
+                desired_resources += [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "metadata": {
+                            "name": "kfp-launcher",
+                            "namespace": namespace,
+                        },
+                        "data": {
+                            "defaultPipelineRoot": kfp_default_pipeline_root,
+                        },
+                    }
+                ]
 
             # Compute status based on observed state.
             desired_status = {
-                "kubeflow-pipelines-ready":
-                    len(children["Secret.v1"]) == 1 and
-                    len(children["ConfigMap.v1"]) == desired_configmap_count and
-                    len(children["Deployment.apps/v1"]) == 2 and
-                    len(children["Service.v1"]) == 2 and
-                    # TODO CANONICAL: This only works if istio is available.  Disabled for now
-                    # len(children["DestinationRule.networking.istio.io/v1alpha3"]) == 1 and
-                    # len(children["AuthorizationPolicy.security.istio.io/v1beta1"]) == 1 and
-                    "True" or "False"
+                "kubeflow-pipelines-ready": len(children["Secret.v1"]) == 1
+                and len(children["ConfigMap.v1"]) == desired_configmap_count
+                and len(children["Deployment.apps/v1"]) == 2
+                and len(children["Service.v1"]) == 2
+                and
+                # TODO CANONICAL: This only works if istio is available.  Disabled for now
+                # len(children["DestinationRule.networking.istio.io/v1alpha3"]) == 1 and
+                # len(children["AuthorizationPolicy.security.istio.io/v1beta1"]) == 1 and
+                "True"
+                or "False"
             }
 
             # Generate the desired child object(s).
@@ -205,50 +225,35 @@ def server_factory(visualization_server_image,
                     "apiVersion": "apps/v1",
                     "kind": "Deployment",
                     "metadata": {
-                        "labels": {
-                            "app": "ml-pipeline-visualizationserver"
-                        },
+                        "labels": {"app": "ml-pipeline-visualizationserver"},
                         "name": "ml-pipeline-visualizationserver",
                         "namespace": namespace,
                     },
                     "spec": {
                         "selector": {
-                            "matchLabels": {
-                                "app": "ml-pipeline-visualizationserver"
-                            },
+                            "matchLabels": {"app": "ml-pipeline-visualizationserver"},
                         },
                         "template": {
                             "metadata": {
-                                "labels": {
-                                    "app": "ml-pipeline-visualizationserver"
-                                },
-                                "annotations": disable_istio_sidecar and {
-                                    "sidecar.istio.io/inject": "false"
-                                } or {},
+                                "labels": {"app": "ml-pipeline-visualizationserver"},
+                                "annotations": disable_istio_sidecar
+                                and {"sidecar.istio.io/inject": "false"}
+                                or {},
                             },
                             "spec": {
-                                "containers": [{
-                                    "image": f"{visualization_server_image}:{visualization_server_tag}",
-                                    "imagePullPolicy":
-                                        "IfNotPresent",
-                                    "name":
-                                        "ml-pipeline-visualizationserver",
-                                    "ports": [{
-                                        "containerPort": 8888
-                                    }],
-                                    "resources": {
-                                        "requests": {
-                                            "cpu": "50m",
-                                            "memory": "200Mi"
-                                        },
-                                        "limits": {
-                                            "cpu": "500m",
-                                            "memory": "1Gi"
+                                "containers": [
+                                    {
+                                        "image": f"{visualization_server_image}:{visualization_server_tag}",
+                                        "imagePullPolicy": "IfNotPresent",
+                                        "name": "ml-pipeline-visualizationserver",
+                                        "ports": [{"containerPort": 8888}],
+                                        "resources": {
+                                            "requests": {"cpu": "50m", "memory": "200Mi"},
+                                            "limits": {"cpu": "500m", "memory": "1Gi"},
                                         },
                                     }
-                                }],
-                                "serviceAccountName":
-                                    "default-editor",
+                                ],
+                                "serviceAccountName": "default-editor",
                             },
                         },
                     },
@@ -300,12 +305,14 @@ def server_factory(visualization_server_image,
                         "namespace": namespace,
                     },
                     "spec": {
-                        "ports": [{
-                            "name": "http",
-                            "port": 8888,
-                            "protocol": "TCP",
-                            "targetPort": 8888,
-                        }],
+                        "ports": [
+                            {
+                                "name": "http",
+                                "port": 8888,
+                                "protocol": "TCP",
+                                "targetPort": 8888,
+                            }
+                        ],
                         "selector": {
                             "app": "ml-pipeline-visualizationserver",
                         },
@@ -316,68 +323,59 @@ def server_factory(visualization_server_image,
                     "apiVersion": "apps/v1",
                     "kind": "Deployment",
                     "metadata": {
-                        "labels": {
-                            "app": "ml-pipeline-ui-artifact"
-                        },
+                        "labels": {"app": "ml-pipeline-ui-artifact"},
                         "name": "ml-pipeline-ui-artifact",
                         "namespace": namespace,
                     },
                     "spec": {
-                        "selector": {
-                            "matchLabels": {
-                                "app": "ml-pipeline-ui-artifact"
-                            }
-                        },
+                        "selector": {"matchLabels": {"app": "ml-pipeline-ui-artifact"}},
                         "template": {
                             "metadata": {
-                                "labels": {
-                                    "app": "ml-pipeline-ui-artifact"
-                                },
-                                "annotations": disable_istio_sidecar and {
-                                    "sidecar.istio.io/inject": "false"
-                                } or {},
+                                "labels": {"app": "ml-pipeline-ui-artifact"},
+                                "annotations": disable_istio_sidecar
+                                and {"sidecar.istio.io/inject": "false"}
+                                or {},
                             },
                             "spec": {
-                                "containers": [{
-                                    "name":
-                                        "ml-pipeline-ui-artifact",
-                                    "image": f"{frontend_image}:{frontend_tag}",
-                                    "imagePullPolicy":
-                                        "IfNotPresent",
-                                    "ports": [{
-                                        "containerPort": 3000
-                                    }],
-                                    "env": [
-                                        {'name': "MINIO_PORT", 'value': minio_port},
-                                        {'name': "MINIO_HOST", 'value': minio_host},
-                                        {'name': "MINIO_NAMESPACE", 'value': minio_namespace},
-                                        {'name': "MINIO_ACCESS_KEY", 'valueFrom':
-                                            {'secretKeyRef':
-                                                 {'key': "accesskey", 'name': 'mlpipeline-minio-artifact'}
-                                             }
-                                         },
-                                        {'name': "MINIO_SECRET_KEY", 'valueFrom':
-                                            {'secretKeyRef':
-                                                 {'key': "secretkey", 'name': 'mlpipeline-minio-artifact'}
-                                             }
-                                         },
-                                    ],
-                                    "resources": {
-                                        "requests": {
-                                            "cpu": "10m",
-                                            "memory": "70Mi"
-                                        },
-                                        "limits": {
-                                            "cpu": "100m",
-                                            "memory": "500Mi"
+                                "containers": [
+                                    {
+                                        "name": "ml-pipeline-ui-artifact",
+                                        "image": f"{frontend_image}:{frontend_tag}",
+                                        "imagePullPolicy": "IfNotPresent",
+                                        "ports": [{"containerPort": 3000}],
+                                        "env": [
+                                            {"name": "MINIO_PORT", "value": minio_port},
+                                            {"name": "MINIO_HOST", "value": minio_host},
+                                            {"name": "MINIO_NAMESPACE", "value": minio_namespace},
+                                            {
+                                                "name": "MINIO_ACCESS_KEY",
+                                                "valueFrom": {
+                                                    "secretKeyRef": {
+                                                        "key": "accesskey",
+                                                        "name": "mlpipeline-minio-artifact",
+                                                    }
+                                                },
+                                            },
+                                            {
+                                                "name": "MINIO_SECRET_KEY",
+                                                "valueFrom": {
+                                                    "secretKeyRef": {
+                                                        "key": "secretkey",
+                                                        "name": "mlpipeline-minio-artifact",
+                                                    }
+                                                },
+                                            },
+                                        ],
+                                        "resources": {
+                                            "requests": {"cpu": "10m", "memory": "70Mi"},
+                                            "limits": {"cpu": "100m", "memory": "500Mi"},
                                         },
                                     }
-                                }],
-                                "serviceAccountName":
-                                    "default-editor"
-                            }
-                        }
-                    }
+                                ],
+                                "serviceAccountName": "default-editor",
+                            },
+                        },
+                    },
                 },
                 # Added from https://github.com/kubeflow/pipelines/pull/6629 to fix
                 # https://github.com/canonical/bundle-kubeflow/issues/423.  This was not yet in
@@ -387,17 +385,10 @@ def server_factory(visualization_server_image,
                 {
                     "apiVersion": "kubeflow.org/v1alpha1",
                     "kind": "PodDefault",
-                    "metadata": {
-                        "name": "access-ml-pipeline",
-                        "namespace": namespace
-                    },
+                    "metadata": {"name": "access-ml-pipeline", "namespace": namespace},
                     "spec": {
                         "desc": "Allow access to Kubeflow Pipelines",
-                        "selector": {
-                            "matchLabels": {
-                                "access-ml-pipeline": "true"
-                            }
-                        },
+                        "selector": {"matchLabels": {"access-ml-pipeline": "true"}},
                         "volumes": [
                             {
                                 "name": "volume-kf-pipeline-token",
@@ -407,27 +398,27 @@ def server_factory(visualization_server_image,
                                             "serviceAccountToken": {
                                                 "path": "token",
                                                 "expirationSeconds": 7200,
-                                                "audience": "pipelines.kubeflow.org"
+                                                "audience": "pipelines.kubeflow.org",
                                             }
                                         }
                                     ]
-                                }
+                                },
                             }
                         ],
                         "volumeMounts": [
                             {
                                 "mountPath": "/var/run/secrets/kubeflow/pipelines",
                                 "name": "volume-kf-pipeline-token",
-                                "readOnly": True
+                                "readOnly": True,
                             }
                         ],
                         "env": [
                             {
                                 "name": "KF_PIPELINES_SA_TOKEN_PATH",
-                                "value": "/var/run/secrets/kubeflow/pipelines/token"
+                                "value": "/var/run/secrets/kubeflow/pipelines/token",
                             }
-                        ]
-                    }
+                        ],
+                    },
                 },
                 {
                     "apiVersion": "v1",
@@ -435,52 +426,53 @@ def server_factory(visualization_server_image,
                     "metadata": {
                         "name": "ml-pipeline-ui-artifact",
                         "namespace": namespace,
-                        "labels": {
-                            "app": "ml-pipeline-ui-artifact"
-                        }
+                        "labels": {"app": "ml-pipeline-ui-artifact"},
                     },
                     "spec": {
-                        "ports": [{
-                            "name":
-                                "http",  # name is required to let istio understand request protocol
-                            "port": 80,
-                            "protocol": "TCP",
-                            "targetPort": 3000
-                        }],
-                        "selector": {
-                            "app": "ml-pipeline-ui-artifact"
-                        }
-                    }
+                        "ports": [
+                            {
+                                "name": "http",  # name is required to let istio understand request protocol
+                                "port": 80,
+                                "protocol": "TCP",
+                                "targetPort": 3000,
+                            }
+                        ],
+                        "selector": {"app": "ml-pipeline-ui-artifact"},
+                    },
                 },
             ]
-            print('Received request:\n', json.dumps(parent, indent=2, sort_keys=True))
-            print('Desired resources except secrets:\n', json.dumps(desired_resources, indent=2, sort_keys=True))
+            print("Received request:\n", json.dumps(parent, indent=2, sort_keys=True))
+            print(
+                "Desired resources except secrets:\n",
+                json.dumps(desired_resources, indent=2, sort_keys=True),
+            )
             # Moved after the print argument because this is sensitive data.
-            desired_resources.append({
-                "apiVersion": "v1",
-                "kind": "Secret",
-                "metadata": {
-                    "name": "mlpipeline-minio-artifact",
-                    "namespace": namespace,
-                },
-                "data": {
-                    "accesskey": minio_access_key,
-                    "secretkey": minio_secret_key,
-                },
-            })
+            desired_resources.append(
+                {
+                    "apiVersion": "v1",
+                    "kind": "Secret",
+                    "metadata": {
+                        "name": "mlpipeline-minio-artifact",
+                        "namespace": namespace,
+                    },
+                    "data": {
+                        "accesskey": minio_access_key,
+                        "secretkey": minio_secret_key,
+                    },
+                }
+            )
 
             return {"status": desired_status, "children": desired_resources}
 
         def do_POST(self):
             # Serve the sync() function as a JSON webhook.
-            observed = json.loads(
-                self.rfile.read(int(self.headers.get("content-length"))))
+            observed = json.loads(self.rfile.read(int(self.headers.get("content-length"))))
             desired = self.sync(observed["parent"], observed["children"])
 
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             self.end_headers()
-            self.wfile.write(bytes(json.dumps(desired), 'utf-8'))
+            self.wfile.write(bytes(json.dumps(desired), "utf-8"))
 
     return HTTPServer((url, int(controller_port)), Controller)
 

--- a/charms/kfp-profile-controller/requirements.txt
+++ b/charms/kfp-profile-controller/requirements.txt
@@ -1,3 +1,5 @@
 ops==1.2.0
 oci-image==1.0.0
 serialized-data-interface<0.4   
+lightkube<0.9
+tenacity<8.1

--- a/charms/kfp-profile-controller/src/charm.py
+++ b/charms/kfp-profile-controller/src/charm.py
@@ -72,7 +72,7 @@ class KfpProfileControllerOperator(CharmBase):
         self.model.unit.status = MaintenanceStatus("Setting pod spec")
 
         deployment_env = {
-            "minio-secret-kfp": {"secret": {"name": "minio-secret-kfp"}},
+            "minio-secret": {"secret": {"name": f"{self.model.app.name}-minio-credentials"}},
             "MINIO_HOST": os["service"],
             "MINIO_PORT": os["port"],
             "MINIO_NAMESPACE": os["namespace"],
@@ -200,7 +200,7 @@ class KfpProfileControllerOperator(CharmBase):
                     },
                     "secrets": [
                         {
-                            "name": "minio-secret-kfp",
+                            "name": f"{self.model.app.name}-minio-credentials",
                             "type": "Opaque",
                             "data": {
                                 k: b64encode(v.encode("utf-8")).decode("utf-8")

--- a/charms/kfp-profile-controller/tests/integration/profile.yaml
+++ b/charms/kfp-profile-controller/tests/integration/profile.yaml
@@ -1,0 +1,11 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+apiVersion: kubeflow.org/v1
+kind: Profile
+metadata:
+  name: profilename
+spec:
+  owner:
+    kind: User
+    name: userid2@email.com

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -13,9 +13,7 @@ from lightkube.generic_resource import create_global_resource
 from lightkube.resources.core_v1 import Namespace, Pod, Secret, ServiceAccount
 from lightkube.types import PatchType
 from pytest_operator.plugin import OpsTest
-
 from tenacity import retry, wait_exponential, stop_after_delay
-
 
 logger = logging.getLogger(__name__)
 
@@ -61,13 +59,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
 
 async def test_status(ops_test: OpsTest):
-    assert ops_test.model.applications["kubeflow-profiles"].units[0].workload_status == "active"
-    assert (
-        ops_test.model.applications["metacontroller-operator"].units[0].workload_status == "active"
-    )
-    assert (
-        ops_test.model.applications["kfp-profile-controller"].units[0].workload_status == "active"
-    )
+    charms = ("kubeflow-profiles", "metacontroller-operator", "kfp-profile-controller")
+    for charm in charms:
+        assert ops_test.model.applications[charm].units[0].workload_status == "active"
 
 
 async def test_profile_creation(lightkube_client, profile):

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -13,7 +13,7 @@ from lightkube.generic_resource import create_global_resource
 from lightkube.resources.core_v1 import Namespace, Pod, Secret, ServiceAccount
 from lightkube.types import PatchType
 from pytest_operator.plugin import OpsTest
-from tenacity import retry, wait_exponential, stop_after_delay
+from tenacity import retry, stop_after_delay, wait_exponential
 
 logger = logging.getLogger(__name__)
 

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -1,18 +1,19 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from base64 import b64decode
 import logging
+from base64 import b64decode
 from pathlib import Path
 
-import yaml
 import lightkube
+import pytest
+import yaml
 from lightkube import codecs
 from lightkube.generic_resource import create_global_resource
 from lightkube.resources.core_v1 import Namespace, Pod, Secret, ServiceAccount
 from lightkube.types import PatchType
-import pytest
 from pytest_operator.plugin import OpsTest
+
 from tenacity import retry, wait_exponential, stop_after_delay
 
 

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -59,6 +59,16 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
 
 
+async def test_status(ops_test: OpsTest):
+    assert ops_test.model.applications["kubeflow-profiles"].units[0].workload_status == "active"
+    assert (
+        ops_test.model.applications["metacontroller-operator"].units[0].workload_status == "active"
+    )
+    assert (
+        ops_test.model.applications["kfp-profile-controller"].units[0].workload_status == "active"
+    )
+
+
 async def test_profile_creation(lightkube_client, profile):
     # Test whether a namespace was created for this profile
     profile_name = profile
@@ -202,8 +212,7 @@ def validate_profile_resources(
 
 
 def test_model_resources(ops_test: OpsTest):
-    """Verifies that the secret was created, secret-key matches the minio config value
-    and that the pods are running"""
+    """Verifies that the secret was created, secret-key matches the minio config value and pods are running"""
     client_secret = lightkube.Client()
     secret = client_secret.get(
         Secret, f"{APP_NAME}-minio-credentials", namespace=ops_test.model_name

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -70,7 +70,7 @@ def lightkube_client() -> lightkube.Client:
 
 
 def _safe_load_file_to_text(filename: str):
-    """Returns the contents of filename if it is an existing file, else it returns filename"""
+    """Returns the contents of filename if it is an existing file, else it returns filename."""
     try:
         text = Path(filename).read_text()
     except FileNotFoundError:
@@ -80,7 +80,7 @@ def _safe_load_file_to_text(filename: str):
 
 @pytest.fixture(scope="session")
 def profile(lightkube_client):
-    """Creates a Profile object in cluster, cleaning it up after tests"""
+    """Creates a Profile object in cluster, cleaning it up after tests."""
     profile_file = "./tests/integration/profile.yaml"
     yaml_text = _safe_load_file_to_text(profile_file)
     yaml_rendered = yaml.safe_load(yaml_text)
@@ -88,8 +88,6 @@ def profile(lightkube_client):
 
     create_all_from_yaml(yaml_file=yaml_text, lightkube_client=lightkube_client)
     yield profilename
-
-    delete_all_from_yaml(yaml_text, lightkube_client)
 
 
 ALLOWED_IF_EXISTS = (None, "replace", "patch")
@@ -109,7 +107,8 @@ def create_all_from_yaml(
     if_exists: [str, None] = None,
     lightkube_client: lightkube.Client = None,
 ):
-    """Creates all k8s resources listed in a YAML file via lightkube
+    """Creates all k8s resources listed in a YAML file via lightkube.
+
     Args:
         yaml_file (str or Path): Either a string filename or a string of valid YAML.  Will attempt
                                  to open a filename at this path, failing back to interpreting the
@@ -134,7 +133,7 @@ def create_all_from_yaml(
             if if_exists is None:
                 raise e
             else:
-                log.info(
+                logger.info(
                     f"Caught {e.status} when creating {obj.metadata.name}.  Trying to {if_exists}"
                 )
                 if if_exists == "replace":
@@ -153,23 +152,6 @@ def create_all_from_yaml(
                     )
 
 
-def delete_all_from_yaml(yaml_file: str, lightkube_client: lightkube.Client = None):
-    """Deletes all k8s resources listed in a YAML file via lightkube
-    Args:
-        yaml_file (str or Path): Either a string filename or a string of valid YAML.  Will attempt
-                                 to open a filename at this path, failing back to interpreting the
-                                 string directly as YAML.
-        lightkube_client: Instantiated lightkube client or None
-    """
-    yaml_text = _safe_load_file_to_text(yaml_file)
-
-    if lightkube_client is None:
-        lightkube_client = lightkube.Client()
-
-    for obj in codecs.load_all_yaml(yaml_text):
-        lightkube_client.delete(type(obj), obj.metadata.name)
-
-
 @retry(
     wait=wait_exponential(multiplier=1, min=1, max=10),
     stop=stop_after_delay(30),
@@ -184,7 +166,6 @@ def validate_profile_resources(
     Retries multiple times using tenacity to allow time for profile-controller to create the
     namespace
     """
-
     namespace = client.get(Namespace, profile_name)
     namespace_name = namespace.metadata.name
 

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -1,11 +1,20 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from base64 import b64decode
 import logging
 from pathlib import Path
 
 import yaml
+import lightkube
+from lightkube import codecs
+from lightkube.generic_resource import create_global_resource
+from lightkube.resources.core_v1 import Namespace, Pod, Secret, ServiceAccount
+from lightkube.types import PatchType
+import pytest
 from pytest_operator.plugin import OpsTest
+from tenacity import retry, wait_exponential, stop_after_delay
+
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +24,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 MINIO_CONFIG = {"access-key": "minio", "secret-key": "minio-secret-key"}
 
 
+@pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
     built_charm_path = await ops_test.build_charm("./")
     logger.info(f"Built charm {built_charm_path}")
@@ -35,19 +45,163 @@ async def test_build_and_deploy(ops_test: OpsTest):
         "minio:object-storage",
     )
 
-    # TODO: Need a better test for checking everything is ok
+    # Deploy charms responsible for CRDs creation
+    await ops_test.model.deploy(entity_url="kubeflow-profiles")
+    await ops_test.model.deploy(entity_url="metacontroller-operator")
+
     # Maybe: await ops_test.model.wait_for_idle(raise_on_error=False, raise_on_blocked=True) ?
     await ops_test.model.wait_for_idle(timeout=60 * 10)
 
 
-# TODO: Real testing requires:
-#  * kubeflow-profile controller, or something that will make namespaces/service accounts in a
-#    similar fashion (some resources deployed to each namespace by kfp-profile-controller use the
-#    `default-editor` service account, which is created by the main kubeflow-profile controller)
-#  * This charm deploying successfully is not a full test of function.  We need to create a new
-#    tracked namespace (namespace that has label pipelines.kubeflow.org/enabled=true) and ensure
-#    all expected resources are deployed and come up successfully (eg: if service account is not
-#    found, deployments will exist but pods will never be "ready")
-#  * check whether secrets and other things get updated based on the config sent to sync.py/kfppc
-#  * could create namespaces with the right pipelines label to trigger the sync, but also need to
-#    create a dummy poddefaults CRD too
+async def test_profile_creation(lightkube_client, profile):
+    # Test whether a namespace was created for this profile
+    profile_name = profile
+    validate_profile_resources(lightkube_client, profile_name)
+
+
+@pytest.fixture(scope="session")
+def lightkube_client() -> lightkube.Client:
+    client = lightkube.Client()
+    create_global_resource(group="kubeflow.org", version="v1", kind="Profile", plural="profiles")
+    return client
+
+
+def _safe_load_file_to_text(filename: str):
+    """Returns the contents of filename if it is an existing file, else it returns filename"""
+    try:
+        text = Path(filename).read_text()
+    except FileNotFoundError:
+        text = filename
+    return text
+
+
+@pytest.fixture(scope="session")
+def profile(lightkube_client):
+    """Creates a Profile object in cluster, cleaning it up after tests"""
+    profile_file = "./tests/integration/profile.yaml"
+    yaml_text = _safe_load_file_to_text(profile_file)
+    yaml_rendered = yaml.safe_load(yaml_text)
+    profilename = yaml_rendered["metadata"]["name"]
+
+    create_all_from_yaml(yaml_file=yaml_text, lightkube_client=lightkube_client)
+    yield profilename
+
+    delete_all_from_yaml(yaml_text, lightkube_client)
+
+
+ALLOWED_IF_EXISTS = (None, "replace", "patch")
+
+
+def _validate_if_exists(if_exists):
+    if if_exists in ALLOWED_IF_EXISTS:
+        return if_exists
+    else:
+        raise ValueError(
+            f"Invalid value for if_exists '{if_exists}'.  Must be one of {ALLOWED_IF_EXISTS}"
+        )
+
+
+def create_all_from_yaml(
+    yaml_file: str,
+    if_exists: [str, None] = None,
+    lightkube_client: lightkube.Client = None,
+):
+    """Creates all k8s resources listed in a YAML file via lightkube
+    Args:
+        yaml_file (str or Path): Either a string filename or a string of valid YAML.  Will attempt
+                                 to open a filename at this path, failing back to interpreting the
+                                 string directly as YAML.
+        if_exists (str): If an object to create already exists, do one of:
+            patch: Try to lightkube.patch the existing resource
+            replace: Try to lightkube.replace the existing resource (not yet implemented)
+            None: Do nothing (lightkube.core.exceptions.ApiError will be raised)
+        lightkube_client: Instantiated lightkube client or None
+    """
+    _validate_if_exists(if_exists)
+
+    yaml_text = _safe_load_file_to_text(yaml_file)
+
+    if lightkube_client is None:
+        lightkube_client = lightkube.Client()
+
+    for obj in codecs.load_all_yaml(yaml_text):
+        try:
+            lightkube_client.create(obj)
+        except lightkube.core.exceptions.ApiError as e:
+            if if_exists is None:
+                raise e
+            else:
+                log.info(
+                    f"Caught {e.status} when creating {obj.metadata.name}.  Trying to {if_exists}"
+                )
+                if if_exists == "replace":
+                    raise NotImplementedError()
+                elif if_exists == "patch":
+                    lightkube_client.patch(
+                        type(obj),
+                        obj.metadata.name,
+                        obj.to_dict(),
+                        patch_type=PatchType.MERGE,
+                    )
+                else:
+                    raise ValueError(
+                        f"Invalid value for if_exists '{if_exists}'.  "
+                        f"Must be one of {ALLOWED_IF_EXISTS}"
+                    )
+
+
+def delete_all_from_yaml(yaml_file: str, lightkube_client: lightkube.Client = None):
+    """Deletes all k8s resources listed in a YAML file via lightkube
+    Args:
+        yaml_file (str or Path): Either a string filename or a string of valid YAML.  Will attempt
+                                 to open a filename at this path, failing back to interpreting the
+                                 string directly as YAML.
+        lightkube_client: Instantiated lightkube client or None
+    """
+    yaml_text = _safe_load_file_to_text(yaml_file)
+
+    if lightkube_client is None:
+        lightkube_client = lightkube.Client()
+
+    for obj in codecs.load_all_yaml(yaml_text):
+        lightkube_client.delete(type(obj), obj.metadata.name)
+
+
+@retry(
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    stop=stop_after_delay(30),
+    reraise=True,
+)
+def validate_profile_resources(
+    client: lightkube.Client,
+    profile_name: str,
+):
+    """Validates that a namespace for a Profile was created, has the expected label,
+    and that a default-editor service account was created.
+    Retries multiple times using tenacity to allow time for profile-controller to create the
+    namespace
+    """
+
+    namespace = client.get(Namespace, profile_name)
+    namespace_name = namespace.metadata.name
+
+    service_account = client.get(ServiceAccount, "default-editor", namespace=namespace_name)
+    assert service_account
+
+    expected_label = "pipelines.kubeflow.org/enabled"
+    expected_label_value = "true"
+    assert expected_label in namespace.metadata.labels
+    assert expected_label_value == namespace.metadata.labels[expected_label]
+
+
+def test_model_resources(ops_test: OpsTest):
+    """Verifies that the secret was created, secret-key matches the minio config value
+    and that the pods are running"""
+    client_secret = lightkube.Client()
+    secret = client_secret.get(
+        Secret, f"{APP_NAME}-minio-credentials", namespace=ops_test.model_name
+    )
+    assert b64decode(secret.data["MINIO_SECRET_KEY"]).decode("utf-8") == MINIO_CONFIG["secret-key"]
+
+    pod_status = client_secret.get(Pod, f"{APP_NAME}-operator-0", namespace=ops_test.model_name)
+    assert pod_status.status.phase == "Running"

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -47,7 +47,10 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploy charms responsible for CRDs creation
     await ops_test.model.deploy(entity_url="kubeflow-profiles")
-    await ops_test.model.deploy(entity_url="metacontroller-operator")
+    await ops_test.model.deploy(
+        entity_url="metacontroller-operator",
+        trust=True,
+    )
 
     # Maybe: await ops_test.model.wait_for_idle(raise_on_error=False, raise_on_blocked=True) ?
     await ops_test.model.wait_for_idle(timeout=60 * 10)

--- a/charms/kfp-profile-controller/tests/integration/test_charm.py
+++ b/charms/kfp-profile-controller/tests/integration/test_charm.py
@@ -194,7 +194,9 @@ def validate_profile_resources(
     client: lightkube.Client,
     profile_name: str,
 ):
-    """Validates that a namespace for a Profile was created, has the expected label,
+    """Tests if the resources associated with Profile were created.
+
+    Validates that a namespace for a Profile was created, has the expected label,
     and that a default-editor service account was created.
     Retries multiple times using tenacity to allow time for profile-controller to create the
     namespace
@@ -212,7 +214,11 @@ def validate_profile_resources(
 
 
 def test_model_resources(ops_test: OpsTest):
-    """Verifies that the secret was created, secret-key matches the minio config value and pods are running"""
+    """Tests if the resources associated with secret's namespace were created.
+
+    Verifies that the secret was created, decoded secret-key matches the minio config value,
+    and that the pods are running.
+    """
     client_secret = lightkube.Client()
     secret = client_secret.get(
         Secret, f"{APP_NAME}-minio-credentials", namespace=ops_test.model_name

--- a/charms/kfp-profile-controller/tests/unit/test_operator.py
+++ b/charms/kfp-profile-controller/tests/unit/test_operator.py
@@ -174,7 +174,7 @@ def test_install_with_all_inputs(harness, oci_resource_data):
     assert b64decode(pod_spec_secret_key).decode("utf-8") == "secret-key"
 
     # confirm that we can serialize the pod spec and that the unit is active
-    yaml.safe_dump(harness.get_pod_spec())
+    yaml.safe_dump(pod_spec)
     assert harness.charm.model.unit.status == ActiveStatus()
 
 


### PR DESCRIPTION
2. Expanded the integration tests:
- Deploy kubeflow-profiles and metacontroller-operator required for CRDs creation
- Create a test profile and corresponding namespace with label pipelines.kubeflow.org/enabled=true
- Ensure that the default-editor service account was created
- Check whether the secret exists and contains the keys
- Ensure that the pods are ready
3. Modified upstream/sync.py and charm.py due to black lint formatting